### PR TITLE
Replace .next() with next() for py3 compatibility

### DIFF
--- a/1_linear_regression.py
+++ b/1_linear_regression.py
@@ -47,7 +47,7 @@ def main():
             cost += train(model, loss, optimizer, X[start:end], Y[start:end])
         print("Epoch = %d, cost = %s" % (i + 1, cost / num_batches))
 
-    w = model.parameters().next().data  # model has only one parameter
+    w = next(model.parameters()).data  # model has only one parameter
     print("w = %.2f" % w.numpy())  # will be approximately 2
 
 if __name__ == "__main__":


### PR DESCRIPTION
In Python3:

```python
AttributeError                            Traceback (most recent call last)
<ipython-input-16-dc3a6e32cc0b> in <module>()
      1 
----> 2 w = model.parameters().next().data # model has only one parameter

AttributeError: 'generator' object has no attribute 'next'
```

next() works in python 2 and python 3.
.next() only works in python 2.